### PR TITLE
Refactor to allow for late binding of models (to facilitate recursion)

### DIFF
--- a/src/Definitions/Definition.php
+++ b/src/Definitions/Definition.php
@@ -3,46 +3,29 @@ declare(strict_types=1);
 
 namespace Funeralzone\ValueObjectGenerator\Definitions;
 
-use Funeralzone\ValueObjectGenerator\Definitions\Models\Model;
+use Funeralzone\ValueObjectGenerator\Definitions\Models\ModelRegister;
 use Funeralzone\ValueObjectGenerator\Definitions\Models\ModelSet;
 
 final class Definition
 {
+    private $modelRegister;
     private $models;
 
     public function __construct(
+        ModelRegister $modelRegister,
         ModelSet $models
     ) {
+        $this->modelRegister = $modelRegister;
         $this->models = $models;
+    }
+
+    public function modelRegister(): ModelRegister
+    {
+        return $this->modelRegister;
     }
 
     public function models(): ModelSet
     {
         return $this->models;
-    }
-
-    public function merge(Definition ...$definitions): Definition
-    {
-        if (count($definitions)) {
-            array_unshift($definitions, $this);
-
-            $models = [];
-            foreach ($definitions as $definition) {
-                foreach ($definition->models->all() as $model) {
-                    /** @var Model $model */
-                    $modelName = $model->definitionName();
-
-                    if (array_key_exists($modelName, $models) === false) {
-                        $models[$modelName] = $model;
-                    }
-                }
-            }
-
-            return new Definition(
-                new ModelSet(array_values($models))
-            );
-        } else {
-            return $this;
-        }
     }
 }

--- a/src/Definitions/Exceptions/DefinitionIsInvalid.php
+++ b/src/Definitions/Exceptions/DefinitionIsInvalid.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Funeralzone\ValueObjectGenerator\Definitions\Exceptions;
 
-final class DefinitionSourceDoesIsInvalid extends \Exception
+final class DefinitionIsInvalid extends \Exception
 {
     public function __construct(string $error)
     {
-        parent::__construct(sprintf('The supplied definition source is invalid - %s', $error));
+        parent::__construct(sprintf('The supplied definition is invalid - %s', $error));
     }
 }

--- a/src/Definitions/Models/DefinedModel.php
+++ b/src/Definitions/Models/DefinedModel.php
@@ -9,6 +9,8 @@ use Funeralzone\ValueObjectGenerator\Testing\ModelTestStipulations;
 
 final class DefinedModel implements Model
 {
+    private $modelRegister;
+    private $parent;
     private $type;
     private $namespace;
     private $definitionName;
@@ -19,6 +21,8 @@ final class DefinedModel implements Model
     private $childModels;
 
     public function __construct(
+        ModelRegister $modelRegister,
+        ?Model $parent,
         ModelType $type,
         ModelNamespace $namespace,
         string $definitionName,
@@ -28,6 +32,8 @@ final class DefinedModel implements Model
         ModelTestStipulations $testStipulations = null,
         ModelSet $childModels
     ) {
+        $this->modelRegister = $modelRegister;
+        $this->parent = $parent;
         $this->type = $type;
         $this->namespace = $namespace;
         $this->definitionName = $definitionName;
@@ -36,6 +42,16 @@ final class DefinedModel implements Model
         $this->decorators = $decorators;
         $this->testStipulations = $testStipulations;
         $this->childModels = $childModels;
+    }
+
+    public function modelRegister(): ModelRegister
+    {
+        return $this->modelRegister;
+    }
+
+    public function parent(): ?Model
+    {
+        return $this->parent;
     }
 
     public function namespace(): ModelNamespace

--- a/src/Definitions/Models/Exceptions/ModelDoesNotExist.php
+++ b/src/Definitions/Models/Exceptions/ModelDoesNotExist.php
@@ -7,6 +7,6 @@ final class ModelDoesNotExist extends \Exception
 {
     public function __construct(string $name)
     {
-        parent::__construct(sprintf('The supplied model "%s" does not exist', $name));
+        parent::__construct(sprintf('The model "%s" does not exist', $name));
     }
 }

--- a/src/Definitions/Models/Model.php
+++ b/src/Definitions/Models/Model.php
@@ -9,6 +9,8 @@ use Funeralzone\ValueObjectGenerator\Testing\ModelTestStipulations;
 
 interface Model
 {
+    public function modelRegister(): ModelRegister;
+    public function parent(): ?Model;
     public function namespace(): ModelNamespace;
     public function definitionName(): string;
     public function type(): ModelType;

--- a/src/Definitions/Models/ModelRegister.php
+++ b/src/Definitions/Models/ModelRegister.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Funeralzone\ValueObjectGenerator\Definitions\Models;
+
+use Funeralzone\ValueObjectGenerator\Definitions\Models\Exceptions\ModelDoesNotExist;
+
+final class ModelRegister
+{
+    private $modelsByName = [];
+
+    public function add(Model $model): void
+    {
+        if ($model instanceof DefinedModel) {
+            $this->modelsByName[$model->definitionName()] = $model;
+        }
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->modelsByName);
+    }
+
+    public function get(string $name): Model
+    {
+        if ($this->has($name) === false) {
+            throw new ModelDoesNotExist($name);
+        }
+        return $this->modelsByName[$name];
+    }
+
+    public function all(): array
+    {
+        return array_values($this->modelsByName);
+    }
+
+    public function allByName(): array
+    {
+        return $this->modelsByName;
+    }
+}

--- a/src/Definitions/Models/ModelSet.php
+++ b/src/Definitions/Models/ModelSet.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 namespace Funeralzone\ValueObjectGenerator\Definitions\Models;
 
 use Countable;
-use Funeralzone\ValueObjectGenerator\Definitions\Models\Exceptions\InvalidModel;
-use Funeralzone\ValueObjectGenerator\Definitions\Models\Exceptions\ModelDoesNotExist;
 
 final class ModelSet implements Countable
 {
-    private $models;
-    private $modelsByName;
+    private $modelRegister;
 
-    public function __construct(array $models)
+    private $models = [];
+
+    public function __construct(ModelRegister $modelRegister)
     {
-        $this->validateInput($models);
-        $this->models = $models;
-        $this->modelsByName = $this->indexModelsByName($models);
+        $this->modelRegister = $modelRegister;
     }
 
     public function all(): array
@@ -24,51 +21,19 @@ final class ModelSet implements Countable
         return $this->models;
     }
 
-    public function allByName(): array
-    {
-        return $this->modelsByName;
-    }
-
-    public function hasByName(string $name): bool
-    {
-        return array_key_exists($name, $this->modelsByName);
-    }
-
-    public function getByName(string $name): Model
-    {
-        if ($this->hasByName($name)) {
-            return $this->modelsByName[$name];
-        } else {
-            throw new ModelDoesNotExist($name);
-        }
-    }
-
     public function count()
     {
         return count($this->models);
     }
 
-    private function indexModelsByName(array $models): array
+    public function add(Model $model): void
     {
-        $indexedModels = [];
-        foreach ($models as $model) {
-            /** @var Model $model */
-            $indexedModels[$model->definitionName()] = $model;
-
-            $indexedModels = array_merge(
-                $indexedModels,
-                $this->indexModelsByName($model->children()->all())
-            );
-        }
-        return $indexedModels;
+        $this->models[] = $model;
+        $this->modelRegister->add($model);
     }
 
-    private function validateInput(array $models): void
+    public function modelRegister(): ModelRegister
     {
-        foreach ($models as $model) {
-            if (! $model instanceof Model) {
-                throw new InvalidModel;
-            }
-        }
+        return $this->modelRegister;
     }
 }

--- a/src/Definitions/Models/ReferencedModel.php
+++ b/src/Definitions/Models/ReferencedModel.php
@@ -9,32 +9,41 @@ use Funeralzone\ValueObjectGenerator\Testing\ModelTestStipulations;
 
 final class ReferencedModel implements Model
 {
-    private $linkedModel;
+    private $modelRegister;
+    private $parent;
     private $definitionName;
     private $properties;
 
     public function __construct(
-        Model $linkedModel,
+        ModelRegister $modelRegister,
+        ?Model $parent,
         string $definitionName,
         ModelProperties $properties
     ) {
-        $this->linkedModel = $linkedModel;
+        $this->modelRegister = $modelRegister;
+        $this->parent = $parent;
         $this->definitionName = $definitionName;
+        $this->properties = $properties;
+    }
 
-        $this->properties = new ModelProperties(array_merge(
-            $linkedModel->properties()->all(),
-            $properties->all()
-        ));
+    public function modelRegister(): ModelRegister
+    {
+        return $this->modelRegister;
+    }
+
+    public function parent(): ?Model
+    {
+        return $this->parent();
     }
 
     public function linkedModel(): Model
     {
-        return $this->linkedModel;
+        return $this->modelRegister->get($this->definitionName);
     }
 
     public function namespace(): ModelNamespace
     {
-        return $this->linkedModel->namespace();
+        return $this->linkedModel()->namespace();
     }
 
     public function definitionName(): string
@@ -44,17 +53,17 @@ final class ReferencedModel implements Model
 
     public function type(): ModelType
     {
-        return $this->linkedModel->type();
+        return $this->linkedModel()->type();
     }
 
     public function externalToDefinition(): bool
     {
-        return $this->linkedModel->externalToDefinition();
+        return $this->linkedModel()->externalToDefinition();
     }
 
     public function children(): ModelSet
     {
-        return $this->linkedModel->children();
+        return $this->linkedModel()->children();
     }
 
     public function creatable(): bool
@@ -64,16 +73,19 @@ final class ReferencedModel implements Model
 
     public function properties(): ModelProperties
     {
-        return $this->properties;
+        return new ModelProperties(array_merge(
+            $this->linkedModel()->properties()->all(),
+            $this->properties->all()
+        ));
     }
 
     public function decorators(): ModelDecoratorSet
     {
-        return $this->linkedModel->decorators();
+        return $this->linkedModel()->decorators();
     }
 
     public function testStipulations(): ?ModelTestStipulations
     {
-        return $this->linkedModel->testStipulations();
+        return $this->linkedModel()->testStipulations();
     }
 }

--- a/src/VOGenerator.php
+++ b/src/VOGenerator.php
@@ -59,6 +59,7 @@ final class VOGenerator
         $modelCount = count($models);
         foreach ($models as $index => $model) {
             $this->progressReporter->generateModelsProgress($modelCount, $index + 1);
+
             $this->modelGenerator->generate($model, $outputFolderPath);
 
             $this->middlewareRunner->run(


### PR DESCRIPTION
This is a **breaking** change and will require a bump to the major release version.

I have refactored the code to allow for "late bound" model references. This means that when referencing a model (not supplying a "type" property in the definitions) the referenced model does not have to be defined before hand. 

The purpose of this work is to allow for recursive referencing within VOs. For example, a composite type could include a set of itself as one of its properties. 

A side effect is that the performance of generating model files has been improved by ~45%. 