### PR TITLE
Introduce "interfaces" for Models

### DIFF
--- a/src/Definitions/Models/DefinedModel.php
+++ b/src/Definitions/Models/DefinedModel.php
@@ -17,6 +17,7 @@ final class DefinedModel implements Model
     private $externalToDefinition;
     private $properties;
     private $decorators;
+    private $implementsInterfaces;
     private $testStipulations;
     private $childModels;
 
@@ -29,6 +30,7 @@ final class DefinedModel implements Model
         bool $externalToDefinition,
         ModelProperties $properties,
         ModelDecoratorSet $decorators,
+        ModelInterfaces $implementsInterfaces,
         ModelTestStipulations $testStipulations = null,
         ModelSet $childModels
     ) {
@@ -40,6 +42,7 @@ final class DefinedModel implements Model
         $this->externalToDefinition = $externalToDefinition;
         $this->properties = $properties;
         $this->decorators = $decorators;
+        $this->implementsInterfaces = $implementsInterfaces;
         $this->testStipulations = $testStipulations;
         $this->childModels = $childModels;
     }
@@ -92,5 +95,10 @@ final class DefinedModel implements Model
     public function testStipulations(): ?ModelTestStipulations
     {
         return $this->testStipulations;
+    }
+
+    public function interfaces(): ModelInterfaces
+    {
+        return $this->implementsInterfaces;
     }
 }

--- a/src/Definitions/Models/Exceptions/InvalidModelInterface.php
+++ b/src/Definitions/Models/Exceptions/InvalidModelInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Funeralzone\ValueObjectGenerator\Definitions\Models\Exceptions;
+
+final class InvalidModelInterface extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(sprintf('The supplied model interface item is not valid'));
+    }
+}

--- a/src/Definitions/Models/Model.php
+++ b/src/Definitions/Models/Model.php
@@ -18,5 +18,6 @@ interface Model
     public function externalToDefinition(): bool;
     public function properties(): ModelProperties;
     public function decorators(): ModelDecoratorSet;
+    public function interfaces(): ModelInterfaces;
     public function testStipulations(): ?ModelTestStipulations;
 }

--- a/src/Definitions/Models/ModelInterface.php
+++ b/src/Definitions/Models/ModelInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Funeralzone\ValueObjectGenerator\Definitions\Models;
+
+use Funeralzone\ValueObjects\Scalars\StringTrait;
+
+class ModelInterface
+{
+    use StringTrait;
+
+    public function name(): string
+    {
+        return ltrim(strrchr($this->string, '\\'), '\\');
+    }
+
+    public function path(): string
+    {
+        return $this->string;
+    }
+}

--- a/src/Definitions/Models/ModelInterfaces.php
+++ b/src/Definitions/Models/ModelInterfaces.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Funeralzone\ValueObjectGenerator\Definitions\Models;
+
+use Funeralzone\ValueObjectGenerator\Definitions\Models\Exceptions\InvalidModelInterface;
+
+class ModelInterfaces
+{
+    private $interfaces;
+
+    public function __construct(array $interfaces)
+    {
+        foreach ($interfaces as $interface) {
+            if (! $interface instanceof ModelInterface) {
+                throw new InvalidModelInterface;
+            }
+        }
+
+        $this->interfaces = $interfaces;
+    }
+
+    public function all(): array
+    {
+        return $this->interfaces;
+    }
+}

--- a/src/Definitions/Models/ReferencedModel.php
+++ b/src/Definitions/Models/ReferencedModel.php
@@ -88,4 +88,9 @@ final class ReferencedModel implements Model
     {
         return $this->linkedModel()->testStipulations();
     }
+
+    public function interfaces(): ModelInterfaces
+    {
+        return $this->linkedModel()->interfaces();
+    }
 }

--- a/src/Definitions/YamlDefinitionConverter.php
+++ b/src/Definitions/YamlDefinitionConverter.php
@@ -13,6 +13,8 @@ use Funeralzone\ValueObjectGenerator\Definitions\Models\Decorators\ModelDecorato
 use Funeralzone\ValueObjectGenerator\Definitions\Models\Decorators\ModelDecoratorSet;
 use Funeralzone\ValueObjectGenerator\Definitions\Models\DefinedModel;
 use Funeralzone\ValueObjectGenerator\Definitions\Models\Model;
+use Funeralzone\ValueObjectGenerator\Definitions\Models\ModelInterface;
+use Funeralzone\ValueObjectGenerator\Definitions\Models\ModelInterfaces;
 use Funeralzone\ValueObjectGenerator\Definitions\Models\ModelNamespace;
 use Funeralzone\ValueObjectGenerator\Definitions\Models\ModelProperties;
 use Funeralzone\ValueObjectGenerator\Definitions\Models\ModelRegister;
@@ -205,6 +207,7 @@ final class YamlDefinitionConverter implements DefinitionConverter
             } else {
                 $modelType = $this->getModelType($definitionInput);
                 $modelDecorators = $this->makeModelDecorators($definitionInput);
+                $modelInterfaces = $this->makeModelInterfaces($definitionInput);
                 $testStipulations = $this->makeModelTestStipulations($definitionInput);
 
                 $parentType = null;
@@ -228,6 +231,7 @@ final class YamlDefinitionConverter implements DefinitionConverter
                     $isModelExternal,
                     $modelProperties,
                     $modelDecorators,
+                    $modelInterfaces,
                     $testStipulations,
                     $modelChildren
                 );
@@ -354,5 +358,14 @@ final class YamlDefinitionConverter implements DefinitionConverter
             }
         }
         return new ModelDecoratorSet($items);
+    }
+
+    private function makeModelInterfaces(array $modelDefinitionInput): ModelInterfaces
+    {
+        $interfaces = [];
+        foreach (($modelDefinitionInput['interfaces'] ?? []) as $nativeInterface) {
+            $interfaces[] = new ModelInterface($nativeInterface);
+        }
+        return new ModelInterfaces($interfaces);
     }
 }

--- a/src/Definitions/YamlDefinitionInputValidator.php
+++ b/src/Definitions/YamlDefinitionInputValidator.php
@@ -34,6 +34,7 @@ final class YamlDefinitionInputValidator implements DefinitionInputValidator
         'export' => 'boolean',
         'instantiationName' => 'string',
         'referenceName' => 'string',
+        'interfaces' => 'array',
 
         'decorators' => 'array',
         'decorators.*.path' => 'required|string',


### PR DESCRIPTION
Introduce the ability to to define interfaces that a ValueObject should adhere to. Interfaces cannot be created through the Generator but instead created manually and included in a model's definition, citing the an array of fully qualified object paths