### PR TITLE
Allow the default root namespace to be overridden in the definition files by specifying a "rootNamespace" directive

### DIFF
--- a/src/Definitions/DefaultDefinitionsCombiner.php
+++ b/src/Definitions/DefaultDefinitionsCombiner.php
@@ -17,14 +17,13 @@ class DefaultDefinitionsCombiner implements DefinitionsCombiner
         /** @var NativeDefinition $nativeDefinition */
         foreach ($nativeDefinitions->all() as $nativeDefinition) {
             try {
-                $definitionNamespace = $nativeDefinition->getNamespace();
-
                 if (count($nativeDefinition->getModel()) === 0) {
                     continue;
                 }
 
                 $combinedModel[] = [
-                    'namespace' => $definitionNamespace,
+                    'rootNamespace' => $nativeDefinition->getRootNamespace(),
+                    'namespace' => $nativeDefinition->getNamespace(),
                     'model' => $nativeDefinition->getModel(),
                 ];
             } catch (Exception $exception) {
@@ -33,7 +32,7 @@ class DefaultDefinitionsCombiner implements DefinitionsCombiner
         }
 
         return new NativeDefinition([
-           'model' => $combinedModel,
+            'model' => $combinedModel,
         ]);
     }
 }

--- a/src/Definitions/DefinitionConverter.php
+++ b/src/Definitions/DefinitionConverter.php
@@ -6,7 +6,7 @@ namespace Funeralzone\ValueObjectGenerator\Definitions;
 interface DefinitionConverter
 {
     public function convert(
-        array $rootNamespace,
+        array $defaultRootNamespace,
         NativeDefinition $nativeDefinition
     ): Definition;
 }

--- a/src/Definitions/NativeDefinition.php
+++ b/src/Definitions/NativeDefinition.php
@@ -17,6 +17,11 @@ final class NativeDefinition
         return $this->definition['model'] ?? [];
     }
 
+    public function getRootNamespace(): string
+    {
+        return $this->definition['rootNamespace'] ?? '';
+    }
+
     public function getNamespace(): string
     {
         return $this->definition['namespace'] ?? '';


### PR DESCRIPTION
`
rootNamespace: My\Root\Namespace\Override

namespace: My\Relative\Namespace

model:

- name: ANiceDateTimeValueObject
  type: RFC3339
`